### PR TITLE
user_management: Make groups and pubkeys optional

### DIFF
--- a/roles/user_management/tasks/add_users_and_groups.yml
+++ b/roles/user_management/tasks/add_users_and_groups.yml
@@ -8,6 +8,7 @@
   with_subelements:
     - "{{ users | default([]) }}"
     - groups
+    - skip_missing: yes
 
 - name: Add users
   user:
@@ -28,3 +29,4 @@
   with_subelements:
     - "{{ users | default([]) }}"
     - pubkeys
+    - skip_missing: yes


### PR DESCRIPTION
It should be possible to skip the groups and pubkeys
variables.

Resolves #7