### PR TITLE
10: Create usergroups also

### DIFF
--- a/roles/user_management/tasks/add_users_and_groups.yml
+++ b/roles/user_management/tasks/add_users_and_groups.yml
@@ -10,6 +10,13 @@
     - groups
     - skip_missing: yes
 
+- name: Create user groups
+  group:
+    name: "{{ item.usergroup }}"
+    state: present
+  when: "create_{{ item.username }} | default([])"
+  loop: "{{ users | default([]) }}"
+
 - name: Add users
   user:
     name: "{{ item.username }}"


### PR DESCRIPTION
--- Why is this change necessary?
The loop which created the necessary groups was not creating
the usergroups.

--- How does it address the issue?
Add task that creates the user groups.