### PR TITLE
iptables: Add restart option for wireguard

### DIFF
--- a/roles/iptables/README.md
+++ b/roles/iptables/README.md
@@ -22,6 +22,7 @@ iptables:
   ip6: true # Allow traffic with IPv4 and IPv6
   flush: true # Flush tables
   restart_docker: true # Restart docker
+  restart_wireguard: true # Restart wireguard interfaces for NAT rules
   save_persistent: true # Save rules persistent
   rules:
     - chain: INPUT # Chain where to append the rule
@@ -35,6 +36,10 @@ iptables:
 **Note to `restart_docker` option**: It is important to restart the docker
 service if `flush` is set. Docker has to write its own rules into iptables
 again.
+
+**Note to `restart_wireguard` option**: It is important to restart the wireguard
+interfaces if `flush` is set. Wireguard maybe has to write its own rules into
+iptables again (depends on configuration).
 
 Example Playbook
 ----------------

--- a/roles/iptables/templates/iptables.sh.j2
+++ b/roles/iptables/templates/iptables.sh.j2
@@ -52,6 +52,15 @@ ip6tables -A {{ rule.chain }} \
 systemctl restart docker
 {% endif %}
 
+{% if item.restart_wireguard is defined and item.restart_wireguard %}
+wg_interfaces=$(ifconfig | grep -oh "wg[0-9]")
+for wg_interface in $wg_interfaces
+do
+  wg-quick down $wg_interface
+  wg-quick up $wg_interface
+done
+{% endif %}
+
 {% if item.save_persistent is defined and item.save_persistent %}
 iptables-save > /etc/iptables/rules.v4
 {% if item.ip6 is defined and item.ip6 %}


### PR DESCRIPTION
If flush is set to true also the rules set by wireguard are flushed.
Therefore the wireguard interfaces need to be restarted to reload
the roles for the service.